### PR TITLE
fix: consolidate stale branch fixes (6 of 8 applied)

### DIFF
--- a/src/yarbo/local.py
+++ b/src/yarbo/local.py
@@ -179,10 +179,6 @@ class YarboLocalClient:
         )
         self._controller_acquired = False
         self._last_status: YarboTelemetry | None = None
-        self._mqtt_log_path = mqtt_log_path
-        self._debug = debug
-        self._debug_raw = debug_raw
-        self._mqtt_capture_max = mqtt_capture_max
 
     # ------------------------------------------------------------------
     # Context manager


### PR DESCRIPTION
## Summary

Manually applies bug fixes from three stale branches to the current codebase. Six of eight fixes applied; two skipped because the code was already correct or the methods don't exist.

| # | Fix | Status |
|---|-----|--------|
| 1 | `publish_command` delegation in `client.py` | ✅ Already correct — skipped |
| 2 | `_last_status` caching in `watch_telemetry` | ✅ Applied |
| 3 | Non-dict data guard in `get_global_params` | ✅ Applied (`get_head_params` n/a) |
| 4 | Operator precedence in `_request_data_feedback` | ✅ Applied |
| 5 | Forward debug params to `MqttTransport` | ✅ Applied |
| 6 | `_ensure_controller()` in camera/firmware methods | ✅ Applied (5 methods) |
| 7 | `get_captured_mqtt` delegates to transport | ✅ Applied |
| 8 | Deduplicate `cmd_roller` / `cmd_vel` | ✅ Not applicable — methods don't exist separately |

### Details

- **Fix 2** (`watch_telemetry`): adds `self._last_status = t` so callers and `_validate_head_type` see fresh telemetry after plan-state fields are merged in.
- **Fix 3** (`get_global_params`): guards against non-dict `data` payloads — returns `{"data": data}` instead of crashing inside `dict()` when firmware sends a list or scalar.
- **Fix 4** (`_request_data_feedback`): adds parentheses so `(msg.get("data", {}) or {}) if isinstance(msg, dict) else {}` evaluates with correct precedence.
- **Fix 5** (`MqttTransport` init): `mqtt_log_path`, `debug`, `debug_raw`, `mqtt_capture_max` are now forwarded to the transport constructor; previously stored as dead instance attributes.
- **Fix 6** (camera / firmware): `check_camera_status`, `camera_calibration`, `firmware_update_now`, `firmware_update_tonight`, `firmware_update_later` each lacked the `await self._ensure_controller()` call required before `_publish_and_wait`.
- **Fix 7** (`get_captured_mqtt`): delegates to `self._transport.get_captured_mqtt()` which properly manages the deque; removes the unreferenced `self._captured_mqtt` list.

## Test plan

- [x] `ruff check src/ tests/` — no issues
- [x] `ruff format src/ tests/` — no changes needed
- [x] `pytest` — 388 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local robot control paths (telemetry caching, controller handshakes, and firmware/camera commands) where subtle behavior changes can affect device interactions, but changes are small, targeted bug fixes.
> 
> **Overview**
> Consolidates several `YarboLocalClient` bug fixes for local MQTT control.
> 
> It now forwards `mqtt_log_path`/`debug`/`debug_raw`/`mqtt_capture_max` into `MqttTransport` and routes `get_captured_mqtt()` through the transport buffer instead of maintaining unused client-side state.
> 
> Telemetry handling is tightened by updating `_last_status` after plan-state fields are merged in `watch_telemetry()`, several commands (`check_camera_status`, `camera_calibration`, and firmware update methods) now call `await self._ensure_controller()`, and `data_feedback` parsing is hardened (operator-precedence fix in `_request_data_feedback`, and `get_global_params` guards against non-dict `data` payloads).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 957e71d3c158325a65b266936a4ed0ce488b30a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->